### PR TITLE
New instructions to install manually

### DIFF
--- a/manual_install_instructions.md
+++ b/manual_install_instructions.md
@@ -4,7 +4,7 @@
 mamba create -n supernet -y && conda activate supernet
 mamba install python=3.10 jax=0.4.13 ml_dtypes optax=0.1.7 flax chex=0.1.83
 mamba install flit -c conda-forge -y
-mamba install lhapdf prompt_toolkit seaborn
+mamba install lhapdf prompt_toolkit seaborn h5py
 pip install reportengine validobj pineappl "ruamel.yaml<0.18.0" ultranest
 ```
 


### PR DESCRIPTION
This PR adds a file describing a new installation procedure that does not require
```
conda install nnpdf
```

It does so by installing most of the things needed with pip and copying and pasting data.

This procedure works fine with Mac Apple Silicon chips, which are currently not supported by the nnpdf conda package.