### PR TITLE
updated name of action for benchmark runcard

### DIFF
--- a/super_net/examples/example_runcards/wmin_super_basis_ct0_20weigths.yaml
+++ b/super_net/examples/example_runcards/wmin_super_basis_ct0_20weigths.yaml
@@ -77,4 +77,4 @@ n_wmin_posterior_samples: 100
 set_name: 231126_lm_wmin_super_basis_ct0_20weigths
 
 actions_:
-- run_wmin_nested_sampling
+- perform_nested_sampling_wmin_fit


### PR DESCRIPTION
This just updates the name of the action from the old to the new: perform_nested_sampling_wmin_fit