### PR TITLE
Set sigma pdf prior

### DIFF
--- a/super_net/examples/example_runcards/grid_pdf_ns_example.yaml
+++ b/super_net/examples/example_runcards/grid_pdf_ns_example.yaml
@@ -56,7 +56,7 @@ lambda_positivity: 1000
 # nested sampling specs
 bayesian_fit: True
 pdf_prior: NNPDF31_nnlo_as_0118
-sigma: 1
+sigma_pdf_prior: 1
 min_num_live_points: 500
 min_ess: 50
 trval_index: 1

--- a/super_net/grid_pdf/grid_pdf/grid_pdf_model.py
+++ b/super_net/grid_pdf/grid_pdf/grid_pdf_model.py
@@ -269,12 +269,18 @@ def grid_pdf_model_prior(
         error68_up = pdf_prior_grid.error68_up
         error68_down = pdf_prior_grid.error68_down
 
+        # Compute the band for a generic sigma_pdf_prior
+        delta = (error68_up - error68_down) / 2
+        mean = (error68_up + error68_down) / 2
+        error_up = mean + delta * sigma_pdf_prior
+        error_down = mean - delta * sigma_pdf_prior
+
         @jax.jit
         def prior_transform(cube):
             """
             TODO
             """
-            params = error68_down + (error68_up - error68_down) * cube
+            params = error_down + (error_up - error_down) * cube
             return params
 
     return prior_transform


### PR DESCRIPTION
This PR allows for the definition of a variable `sigma_pdf_prior`, which allows to set the width of the uniform pdf prior distribution.

Before it was always returning a 68% CL band around the central replica.