### PR TITLE
Substitute flavour_mapping with flavour_indices

### DIFF
--- a/super_net/examples/example_runcards/grid_pdf_ns_example.yaml
+++ b/super_net/examples/example_runcards/grid_pdf_ns_example.yaml
@@ -64,6 +64,7 @@ vectorized: False
 ndraw_max: 500
 
 # grid specs
+flavour_mapping: ["\\Sigma", "g", V]
 xgrids:
   photon: []
   \Sigma: [0.01, 0.02, 0.1, 0.2]

--- a/super_net/grid_pdf/grid_pdf/grid_pdf_fit.py
+++ b/super_net/grid_pdf/grid_pdf/grid_pdf_fit.py
@@ -14,7 +14,7 @@ def make_bayesian_pdf_grid_fit(
     grid_pdf_model_prior,
     interpolate_grid,
     reduced_xgrids,
-    flavour_mapping=FLAVOUR_MAPPING,
+    flavour_indices,
     min_num_live_points=400,
     min_ess=40,
     log_dir="ultranest_logs",
@@ -53,7 +53,7 @@ def make_bayesian_pdf_grid_fit(
         return -0.5 * _chi2_with_positivity(pdf)
 
     parameters = [
-        f"{FK_FLAVOURS[i]}({j})" for i in flavour_mapping for j in reduced_xgrids[i]
+        f"{FK_FLAVOURS[i]}({j})" for i in flavour_indices for j in reduced_xgrids[i]
     ]
 
     sampler = ultranest.ReactiveNestedSampler(


### PR DESCRIPTION
This PR fixes a problem introduced by the PR https://github.com/J-M-Moore/super_net/pull/47 , which broke the functioning of the grid_pdf which relied on the variable `flavour_mapping` to be a list of integers. Now the variable is called `flavour_indices` and the code has been adapted to it.