### PR TITLE
New black version

### DIFF
--- a/super_net/__init__.py
+++ b/super_net/__init__.py
@@ -1,3 +1,4 @@
 """SuperNet: A new PDF fitting framework.
 """
+
 __version__ = "0.1.0"

--- a/super_net/api.py
+++ b/super_net/api.py
@@ -14,6 +14,7 @@ Simple Usage:
 >> fig.show()
 
 """
+
 import logging
 
 from reportengine import api

--- a/super_net/app.py
+++ b/super_net/app.py
@@ -4,6 +4,7 @@ super_net.app.py
 Author: Mark N. Costantini
 Date: 11.11.2023
 """
+
 from validphys.app import App
 from super_net.config import SuperNetConfig
 

--- a/super_net/models/grid_pdf/grid_pdf/__init__.py
+++ b/super_net/models/grid_pdf/grid_pdf/__init__.py
@@ -1,4 +1,5 @@
 """
 grid_pdf: Not a PDF parameterisation, the PDF itself
 """
+
 __version__ = "0.1.0"

--- a/super_net/models/grid_pdf/grid_pdf/utils.py
+++ b/super_net/models/grid_pdf/grid_pdf/utils.py
@@ -6,6 +6,7 @@ Module containing util functions for grid PDF fits.
 Author: Luca Mantani
 Date: 18.12.2023
 """
+
 import logging
 from datetime import datetime
 import jax
@@ -70,11 +71,13 @@ def closure_test_central_pdf_grid(
     # the flavour selection/mapping is then done by flavour_mapping (flavour_indices)
     reduced_pdfgrid = jnp.array(
         [
-            convolution.evolution.grid_values(closure_test_pdf, [fl], x_vals, [Q0])
-            .squeeze(-1)[0]
-            .squeeze(0)
-            if x_vals
-            else jnp.zeros(length_reduced_xgrids)
+            (
+                convolution.evolution.grid_values(closure_test_pdf, [fl], x_vals, [Q0])
+                .squeeze(-1)[0]
+                .squeeze(0)
+                if x_vals
+                else jnp.zeros(length_reduced_xgrids)
+            )
             for fl, x_vals in xgrids.items()
         ],
     )

--- a/super_net/models/wmin/wmin/__init__.py
+++ b/super_net/models/wmin/wmin/__init__.py
@@ -1,4 +1,5 @@
 """
 Wmin: A PDF parametrisation.
 """
+
 __version__ = "0.1.0"

--- a/super_net/models/wmin/wmin/api.py
+++ b/super_net/models/wmin/wmin/api.py
@@ -14,6 +14,7 @@ Simple Usage:
 >> fig.show()
 
 """
+
 import logging
 
 from reportengine import api

--- a/super_net/models/wmin/wmin/app.py
+++ b/super_net/models/wmin/wmin/app.py
@@ -4,6 +4,7 @@ wmin.app.py
 Author: Mark N. Costantini
 Date: 11.11.2023
 """
+
 from super_net.app import SuperNetApp
 from wmin.config import WminConfig
 

--- a/super_net/models/wmin/wmin/checks.py
+++ b/super_net/models/wmin/wmin/checks.py
@@ -1,6 +1,7 @@
 """
 TODO
 """
+
 from reportengine.checks import make_check, CheckError
 
 

--- a/super_net/models/wmin/wmin/tests/conftest.py
+++ b/super_net/models/wmin/wmin/tests/conftest.py
@@ -1,4 +1,5 @@
 """"""
+
 RNG_SEED_WEIGHTS = 0xABCDEF
 
 """"""


### PR DESCRIPTION
This PR reformats the code with the new black 2024 version, which apparently has changed a bit the style and that's the reason our code does not pass the test anymore. 

Make sure you update your black to version 24.1.0.