### PR TITLE
Add command line argument for output directory

### DIFF
--- a/super_net/app.py
+++ b/super_net/app.py
@@ -7,6 +7,7 @@ Date: 11.11.2023
 
 from validphys.app import App
 from super_net.config import SuperNetConfig, Environment
+import pathlib
 
 
 super_net_providers = [
@@ -49,7 +50,22 @@ class SuperNetApp(App):
             default=0,
         )
 
+        parser.add_argument(
+            "-o",
+            "--output",
+            nargs="?",
+            default=None,
+            help="Name of the output directory.",
+        )
+
         return parser
+
+    def get_commandline_arguments(self, cmdline=None):
+        """Get commandline arguments"""
+        args = super().get_commandline_arguments(cmdline)
+        if args["output"] is None:
+            args["output"] = pathlib.Path(args["config_yml"]).stem
+        return args
 
 
 def main():

--- a/super_net/models/grid_pdf/grid_pdf/app.py
+++ b/super_net/models/grid_pdf/grid_pdf/app.py
@@ -22,28 +22,6 @@ grid_pdf_providers = [
 class GridPdfApp(SuperNetApp):
     config_class = GridPdfConfig
 
-    @property
-    def argparser(self):
-        """Parser arguments for grid_pdf app can be added here"""
-        parser = super().argparser
-
-        parser.add_argument(
-            "-o",
-            "--output",
-            nargs="?",
-            default=None,
-            help="Name of the output directory.",
-        )
-
-        return parser
-
-    def get_commandline_arguments(self, cmdline=None):
-        """Get commandline arguments"""
-        args = super().get_commandline_arguments(cmdline)
-        if args["output"] is None:
-            args["output"] = pathlib.Path(args["config_yml"]).stem
-        return args
-
 
 def main():
     a = GridPdfApp(name="grid_pdf", providers=grid_pdf_providers)

--- a/super_net/models/wmin/wmin/app.py
+++ b/super_net/models/wmin/wmin/app.py
@@ -22,28 +22,6 @@ wmin_providers = [
 class WminApp(SuperNetApp):
     config_class = WminConfig
 
-    @property
-    def argparser(self):
-        """Parser arguments for wmin app can be added here"""
-        parser = super().argparser
-
-        parser.add_argument(
-            "-o",
-            "--output",
-            nargs="?",
-            default=None,
-            help="Name of the output directory.",
-        )
-
-        return parser
-
-    def get_commandline_arguments(self, cmdline=None):
-        """Get commandline arguments"""
-        args = super().get_commandline_arguments(cmdline)
-        if args["output"] is None:
-            args["output"] = pathlib.Path(args["config_yml"]).stem
-        return args
-
 
 def main():
     a = WminApp(name="wmin", providers=wmin_providers)


### PR DESCRIPTION
This commit adds a command line argument for specifying the output directory in the `SuperNetApp` class.

Previously these were defined in the models classes, but I think we want the output to be the name of the runcard by default for all models, so it's better to have it in the supernet class.