### PR TITLE
Write replica index in mc results

### DIFF
--- a/super_net/models/grid_pdf/grid_pdf/grid_pdf_fit.py
+++ b/super_net/models/grid_pdf/grid_pdf/grid_pdf_fit.py
@@ -349,7 +349,7 @@ def perform_single_mc_gridpdf_fit(
         f"{FK_FLAVOURS[i]}({j})" for i in flavour_indices for j in reduced_xgrids[i]
     ]
 
-    df = pd.DataFrame([sample], columns=parameters)
+    df = pd.DataFrame([sample], columns=parameters, index=[replica_index])
     # if mc_result.csv already exists, append to it
     if os.path.isfile(str(output_path) + "/mc_result.csv"):
         df.to_csv(str(output_path) + "/mc_result.csv", mode="a", header=False)


### PR DESCRIPTION
This PR adds the replica index in the functioning of the `perform_single_mc_fit` routine, so that even if executed in different order, we know which one corresponds to which replica.