### PR TITLE
Add MPI parallelization for evolving PDF exportgrids

### DIFF
--- a/colibri/scripts/evolve_fit.py
+++ b/colibri/scripts/evolve_fit.py
@@ -99,8 +99,10 @@ def main():
 
         # If no LHAPDF folder exists, create one
         lhapdf_destination = lhapdf_path() + "/" + args.fit_name
-        if not os.path.exists(lhapdf_destination):
+        if rank == 0 and not os.path.exists(lhapdf_destination):
             os.mkdir(lhapdf_destination)
+        # Synchronize to ensure all processes have finished
+        comm.Barrier()
 
         genpdf.export.dump_info(lhapdf_destination, info)
 


### PR DESCRIPTION
This PR addresses #118. It does so using mpi. If one wants to run the evolution in parallel with 8 workers, the command is

`mpiexec -n 8 evolve_fit folder_name`

It does so without copying the eko.tar, I guess the mpi execution takes care that the reading is done properly.