### PR TITLE
vectorisation à la Moore 

### DIFF
--- a/colibri/loss_functions.py
+++ b/colibri/loss_functions.py
@@ -133,6 +133,6 @@ def make_chi2_with_positivity(
 
     if vectorized:
         # jnp.vectorize(chi2, signature="(m,n)->()")
-        return jax.vmap(chi2, in_axes=(0,), out_axes=0) 
+        return jax.vmap(chi2, in_axes=(0,), out_axes=0)
 
     return chi2


### PR DESCRIPTION
Vectorize loss functions in `loss_functions.py` using `jax.vmap` (can also be done with jnp.vectorize).

I decided to have vmap instead of jnp.vectorize. Both give the same speed up, however, I think that it's nice to have an example of vmap in the code as well.