### PR TITLE
Change fit CI trigger

### DIFF
--- a/.github/workflows/mc_fit_grid_pdf.yml
+++ b/.github/workflows/mc_fit_grid_pdf.yml
@@ -1,4 +1,5 @@
 # This workflow tests that the MC fit in main and the one in the PR are consistent
+# triggered by PR review submission or edit
 
 name: Monte Carlo CI grid_pdf model
 

--- a/.github/workflows/mc_fit_wmin.yml
+++ b/.github/workflows/mc_fit_wmin.yml
@@ -1,4 +1,5 @@
 # This workflow tests that the MC fit in main and the one in the PR are consistent
+# triggered by PR review submission or edit
 
 name: Monte Carlo CI wmin model
 

--- a/.github/workflows/ns_fit_grid_pdf.yml
+++ b/.github/workflows/ns_fit_grid_pdf.yml
@@ -1,4 +1,5 @@
 # This workflow tests that the NS fit in main and the one in the PR are consistent
+# triggered by PR review submission or edit
 
 name: Nested Sampling CI grid_pdf model
 

--- a/.github/workflows/ns_fit_wmin.yml
+++ b/.github/workflows/ns_fit_wmin.yml
@@ -1,4 +1,5 @@
 # This workflow tests that the NS fit in main and the one in the PR are consistent
+# triggered by PR review submission or edit
 
 name: Nested Sampling CI wmin model
 


### PR DESCRIPTION
This PR changes the trigger of the fit CI actions so that it's not on pushes but only when a review is submitted or edited.