### PR TITLE
Fix tests crushing due to new commondata

### DIFF
--- a/colibri/tests/test_commondata_utils.py
+++ b/colibri/tests/test_commondata_utils.py
@@ -43,9 +43,10 @@ def test_experimental_commondata_tuple():
         path = TEST_COMMONDATA_FOLDER / (
             TEST_DATASETS["dataset_inputs"][i]["dataset"] + "_commondata.csv"
         )
+
         assert_allclose(
-            result[i].commondata_table.iloc[:, 1:].to_numpy(dtype=float),
-            pd.read_csv(path).iloc[:, 1:].to_numpy(dtype=float),
+            result[i].commondata_table.iloc[:, 1:]["data"].values,
+            pd.read_csv(path).iloc[:, 1:]["data"].values,
         )
 
 


### PR DESCRIPTION
This PR tries to fix the tests that crush because of the new commondata that has been merged in nnpdf.

Other ways of possibly fixing this are loading data with variant version but this can be problematic since we need new theories computed with eko and these are not compatible anymore with legacy data.

Another problem is that the new commondata has different commondata table since we are not keeping both ADD and MULT anymore