### PR TITLE
removed init_output method that was overriding reportnegine

### DIFF
--- a/colibri/config.py
+++ b/colibri/config.py
@@ -74,6 +74,13 @@ class Environment(Environment):
                 except shutil.SameFileError:
                     pass
 
+        # only master process creates the figures and tables folders
+        if rank == 0:
+            self.figures_folder = self.output_path / "figures"
+            self.figures_folder.mkdir(exist_ok=True)
+            self.tables_folder = self.output_path / "tables"
+            self.tables_folder.mkdir(exist_ok=True)
+
 
 class colibriConfig(Config):
     """


### PR DESCRIPTION
@LucaMantani  I think we need to add this back.
It is useful to run plots with the colibri executable, a good example is the `plot_data_chi2_colibri` function that you wrote.