### PR TITLE
make a colibri fit compatible with validphys standards

### DIFF
--- a/colibri/config.py
+++ b/colibri/config.py
@@ -83,10 +83,10 @@ class Environment(Environment):
 
         # only master process creates the figures and tables folders
         if rank == 0:
-            self.figure_folder = (self.output_path/'figures')
+            self.figure_folder = self.output_path / "figures"
             self.figure_folder.mkdir(exist_ok=True)
 
-            self.table_folder = (self.output_path/'tables')
+            self.table_folder = self.output_path / "tables"
             self.table_folder.mkdir(exist_ok=True)
 
 


### PR DESCRIPTION
New scripts that does the following to a colibri fit

- generates a `filter.yml` file by copying the `input/runcard.yaml`
- generates an md5 hash of `filter.yml`
- copies or moves (depending on flags) fit to `colibri/results` in the environment