### PR TITLE
Fix analytic fit for linear models with intercept

### DIFF
--- a/colibri/analytic_fit.py
+++ b/colibri/analytic_fit.py
@@ -54,7 +54,7 @@ def analytic_fit(
     The assumption is that the model is linear with an intercept:
     T(w) = T(0) + X w.
     The linear problem to solve is through minimisation of the chi2:
-    chi2 = (D - (T(0) +X w))^T Sigma^-1 (D - (T(0) + X w)) = (Y - X w)^T Sigma^-1 (Y - X w)
+    chi2 = (D - (T(0) + X w))^T Sigma^-1 (D - (T(0) + X w)) = (Y - X w)^T Sigma^-1 (Y - X w)
     with Y = D - T(0).
 
     Parameters


### PR DESCRIPTION
This PR fixes a bad bug of the analytic fit which was affecting the wmin model only. While the grid_pdf is truly a linear model, i.e. f = A w, in the case of the wmin model there is an intercept: f = f0 + A w. This was not taken into account in the previous implementation.

I verified, in a simple fit, that the new analytic routine reproduces the Nested Sampling result:
<img width="1311" alt="Screenshot 2024-04-28 at 20 18 44" src="https://github.com/HEP-PBSP/colibri/assets/20224661/4bcf2890-83f4-435b-a544-a1ba3a1a00d5">
