### PR TITLE
Add codecov.yml configuration file

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: 30% # Set your desired coverage threshold for the project
+    patch:
+      default:
+        target: 0% # Set your desired coverage threshold for the patch (PR)


### PR DESCRIPTION
This PR adds a codecov.yml file with custom thresholds for the target coverage. I set them extremely low (whole project 30% and patch 0%) because right now we have a low coverage and tests would always fail, which is annoying. 

I suggest that we increase the thresholds in the future.