### PR TITLE
added ultranest to env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - lhapdf
   - pandoc
   - mpi4py
+  - ultranest
   - pip
   - pip:
     - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ python = "^3.9"
 prompt_toolkit = "*"
 h5py = "*"
 
-ultranest = "*" 
 jax = "*"
 optax = "*"
 flax = "*"


### PR DESCRIPTION
I added ultranest to the env (installed trough conda) and removed it from the pyproject file (installed trough pip).
If I do so, then installation goes trough well. Otherwise, I get an import error due to ultranest.

This one seems to be the same to the one that @J-M-Moore was getting



```
ImportError: dlopen(/Users/markcostantini/arm64_miniconda3/envs/test_delme/lib/python3.12/site-packages/ultranest/mlfriends.cpython-312-darwin.so, 0x0002): tried: '/Users/markcostantini/arm64_miniconda3/envs/test_delme/lib/python3.12/site-packages/ultranest/mlfriends.cpython-312-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/markcostantini/arm64_miniconda3/envs/test_delme/lib/python3.12/site-packages/ultranest/mlfriends.cpython-312-darwin.so' (no such file), '/Users/markcostantini/arm64_miniconda3/envs/test_delme/lib/python3.12/site-packages/ultranest/mlfriends.cpython-312-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))

```