### PR TITLE
Step sampler calibration

### DIFF
--- a/colibri/utils.py
+++ b/colibri/utils.py
@@ -372,28 +372,3 @@ def compute_determinants_of_principal_minors(C):
     determinants.append(1.0)
 
     return np.array(determinants)[::-1]
-
-def process_dict_to_yaml(d):
-    """
-    Process a dictionary to a yaml file.
-    The function converts numpy arrays to lists and numpy floats to Python floats.
-
-    Parameters
-    ----------
-    d : dict
-        The dictionary to process.
-    
-    Returns
-    -------
-    dict
-        The processed dictionary.
-    """
-    for key, value in d.items():
-        if isinstance(value, dict):
-            process_dict_to_yaml(value)
-        elif isinstance(value, np.ndarray):
-            d[key] = value.tolist()
-        elif isinstance(value, np.float64):
-            d[key] = value.item()
-    
-    return d


### PR DESCRIPTION
This pull request introduces a new function to calibrate the stepsampler and makes several changes to the `ultranest_fit.py` file to improve the ultranest fitting process. The most important changes include importing the `calibrator` module, adding the `calibrate_stepsampler` function, and initializing the ultranest sampler within the `ultranest_fit` function.

### Key Changes:

**New Functionality:**
* Added the `calibrate_stepsampler` function to handle the calibration of the stepsampler, which includes setting the ultranest seed, initializing the sampler, and running the calibration.

**Imports:**
* Added import for `calibrator` from the `ultranest` module.

**Modifications to `ultranest_fit`:**
* Initialized the ultranest sampler within the `ultranest_fit` function to improve the fitting process.
* Added a comment to initialize `fit_result` to avoid `UnboundLocalError`.