### PR TITLE
changed default testing theory to 40_000_000 

### DIFF
--- a/colibri/tests/test_runcards/test_grid_pdf_bayes_L0.yaml
+++ b/colibri/tests/test_runcards/test_grid_pdf_bayes_L0.yaml
@@ -10,7 +10,7 @@ dataset_inputs:
   - {'dataset': 'SLACP_dwsh'}
   - {'dataset': 'SLACD_dw_ite'}
 
-theoryid: 401                         # The theory from which the predictions are drawn.
+theoryid: 40_000_000                         # The theory from which the predictions are drawn.
 
 use_cuts: internal                     # The kinematic cuts to be applied to the data.
 
@@ -71,7 +71,8 @@ grid_pdf_settings:
 bayesian_fit: True
 # Nested Sampling settings
 ns_settings:
-  n_posterior_samples: 100
+  sampler_plot: False
+  n_posterior_samples: 1
   ReactiveNS_settings:
     vectorized: False
     ndraw_max: 500

--- a/colibri/tests/test_runcards/test_grid_pdf_mc_L0.yaml
+++ b/colibri/tests/test_runcards/test_grid_pdf_mc_L0.yaml
@@ -10,7 +10,7 @@ dataset_inputs:
   - {'dataset': 'SLAC_NC_NOTFIXED_P_DW_EM-F2', 'variant': 'legacy'}
   - {'dataset': 'SLAC_NC_NOTFIXED_D_DW_EM-F2', 'variant': 'legacy'}
 
-theoryid: 401                         # The theory from which the predictions are drawn.
+theoryid: 40_000_000                         # The theory from which the predictions are drawn.
 use_cuts: internal                     # The kinematic cuts to be applied to the data.
 
 closure_test_level: 0                  # The closure test level: False for experimental, level 0

--- a/colibri/tests/test_runcards/test_wmin_bayes_L0.yaml
+++ b/colibri/tests/test_runcards/test_wmin_bayes_L0.yaml
@@ -10,7 +10,7 @@ dataset_inputs:
   - {'dataset': 'SLACP_dwsh'}
   - {'dataset': 'SLACD_dw_ite'}
 
-theoryid: 401                          # The theory from which the predictions are drawn.
+theoryid: 40_000_000                          # The theory from which the predictions are drawn.
 use_cuts: internal                     # The kinematic cuts to be applied to the data.
 
 closure_test_level: 0                  # The closure test level: False for experimental, level 0
@@ -56,7 +56,8 @@ wmin_settings:
 bayesian_fit: True
 # Nested Sampling settings
 ns_settings:
-  n_posterior_samples: 100
+  sampler_plot: False
+  n_posterior_samples: 1
   ReactiveNS_settings:
     vectorized: False
     ndraw_max: 500

--- a/colibri/tests/test_runcards/test_wmin_mc_L0.yaml
+++ b/colibri/tests/test_runcards/test_wmin_mc_L0.yaml
@@ -10,7 +10,7 @@ dataset_inputs:
   - {'dataset': 'SLACP_dwsh'}
   - {'dataset': 'SLACD_dw_ite'}
 
-theoryid: 401                          # The theory from which the predictions are drawn.
+theoryid: 40_000_000                          # The theory from which the predictions are drawn.
 use_cuts: internal                     # The kinematic cuts to be applied to the data.
 
 closure_test_level: 0                  # The closure test level: False for experimental, level 0


### PR DESCRIPTION
Theory 40_000_000 is lightweight now since it does not come with an EKO.
So no need to use theory 401 anymore