### PR TITLE
Fix mc_postfit for one replica

### DIFF
--- a/colibri/scripts/mc_postfit.py
+++ b/colibri/scripts/mc_postfit.py
@@ -91,8 +91,8 @@ def main():
 
         index = int(replica.name.split("_")[1])
 
-        chi2_pass = loss < chi2_threshold
-        nsigma_pass = loss - mean_loss < nsigma_threshold * std_loss
+        chi2_pass = loss <= chi2_threshold
+        nsigma_pass = loss - mean_loss <= nsigma_threshold * std_loss
 
         # Check if final loss is above the threshold
         if chi2_pass and nsigma_pass:


### PR DESCRIPTION
This PR fixes the mc_postfit so that it passes also with one replica, solving #368 .

Problem was that if there only one replica, the nsigma criterion yields 0 < 0 by definition. Problem is solved if the check is 0 <= 0.

I also added the equal sign for the chi2 criterium but it does not really matter, just for symmetry.