### PR TITLE
mc_initialiser options

### DIFF
--- a/colibri/mc_initialisation.py
+++ b/colibri/mc_initialisation.py
@@ -79,7 +79,7 @@ def mc_initial_parameters(pdf_model, mc_initialiser_settings, replica_index):
             means = jnp.zeros(len(param_names))
             stds = jnp.array([std_dict.get(p, 1.0) for p in param_names])
 
-        # Nothing provided
+        # Neither means nor stds provided
         else:
             if (mean_val is None) and (std_val is None):
                 log.warning(

--- a/colibri/mc_initialisation.py
+++ b/colibri/mc_initialisation.py
@@ -45,66 +45,50 @@ def mc_initial_parameters(pdf_model, mc_initialiser_settings, replica_index):
     param_names = pdf_model.param_names
 
     if mc_initialiser_settings["type"] == "normal":
-        mean_dict = mc_initialiser_settings.get("means", None)
-        std_dict = mc_initialiser_settings.get("stds", None)
+        means_setting = mc_initialiser_settings.get("means", 0.0)
+        stds_setting = mc_initialiser_settings.get("stds", 1.0)
 
-        mean_val = mc_initialiser_settings.get("mean_val", None)
-        std_val = mc_initialiser_settings.get("std_val", None)
+        if (
+            "means" not in mc_initialiser_settings
+            and "stds" not in mc_initialiser_settings
+        ):
+            log.warning(
+                "mc_initialiser_settings: No 'means' or 'stds' provided. "
+                "Using default normal distribution N(0, 1) for all parameters."
+            )
 
-        # Both 'means' and 'stds' provided
-        if (mean_dict is not None) and (std_dict is not None):
-            if len(mean_dict) != len(param_names) or len(std_dict) != len(param_names):
-                raise ValueError(
-                    f"'means' and 'stds' must have exactly one entry per parameter "
-                    f"(you wrote {len(mean_dict)} means and {len(std_dict)} stds for {len(param_names)} parameters)"
-                )
-            means = jnp.array([mean_dict[p] for p in param_names])
-            stds = jnp.array([std_dict[p] for p in param_names])
-
-        # Only 'means' provided
-        elif mean_dict is not None:
+        if "means" in mc_initialiser_settings and "stds" not in mc_initialiser_settings:
             log.warning(
                 "mc_initialiser_settings: 'means' provided without 'stds'. "
-                "Using std=1.0 for all parameters."
+                "Using default std=1.0 for all parameters."
             )
-            means = jnp.array([mean_dict.get(p, 0.0) for p in param_names])
-            stds = jnp.ones(len(param_names))
 
-        # Only 'stds' provided
-        elif std_dict is not None:
+        if "stds" in mc_initialiser_settings and "means" not in mc_initialiser_settings:
             log.warning(
                 "mc_initialiser_settings: 'stds' provided without 'means'. "
-                "Using mean=0.0 for all parameters."
+                "Using default mean=0.0 for all parameters."
             )
-            means = jnp.zeros(len(param_names))
-            stds = jnp.array([std_dict.get(p, 1.0) for p in param_names])
 
-        # Neither means nor stds provided
-        else:
-            if (mean_val is None) and (std_val is None):
-                log.warning(
-                    "mc_initialiser_settings: 'means' and 'stds' not provided. "
-                    "Using default mean=0.0 and std=1.0 for all parameters."
-                )
-                mval = 0.0
-                sval = 1.0
-            elif (mean_val is not None) and (std_val is not None):
-                mval = mean_val
-                sval = std_val
-            elif (mean_val is not None) and (std_val is None):
-                raise ValueError("mc_initialiser_settings: 'std_val' missing.")
-            elif (mean_val is None) and (std_val is not None):
-                raise ValueError("mc_initialiser_settings: 'mean_val' missing.")
-            means = jnp.full(len(param_names), mval)
-            stds = jnp.full(len(param_names), sval)
+        def expand(setting, default, name):
+            # If dict → check consistency
+            if isinstance(setting, dict):
+                if len(setting) != len(param_names):
+                    raise ValueError(
+                        f"'{name}' dict must have one entry per parameter "
+                        f"(got {len(setting)} for {len(param_names)} parameters)."
+                    )
+                return jnp.array([setting.get(p, default) for p in param_names])
+            # If scalar → broadcast
+            elif isinstance(setting, (int, float)):
+                return jnp.full(len(param_names), setting)
+            else:
+                raise TypeError(f"'{name}' must be dict or scalar, got {type(setting)}")
 
-        normal_samples = jax.random.normal(
-            key=random_seed,
-            shape=(len(param_names),),
-        )
+        means = expand(means_setting, 0.0, "means")
+        stds = expand(stds_setting, 1.0, "stds")
 
-        initial_values = means + stds * normal_samples
-        return initial_values
+        normal_samples = jax.random.normal(key=random_seed, shape=(len(param_names),))
+        return means + stds * normal_samples
 
     if mc_initialiser_settings["type"] == "uniform":
         if "bounds" in mc_initialiser_settings:

--- a/colibri/mc_initialisation.py
+++ b/colibri/mc_initialisation.py
@@ -45,25 +45,58 @@ def mc_initial_parameters(pdf_model, mc_initialiser_settings, replica_index):
     param_names = pdf_model.param_names
 
     if mc_initialiser_settings["type"] == "normal":
-        mean_dict = mc_initialiser_settings.get("means", {})
-        std_dict = mc_initialiser_settings.get("stds", {})
+        mean_dict = mc_initialiser_settings.get("means", None)
+        std_dict = mc_initialiser_settings.get("stds", None)
 
-        # Default mean = 0.0, std = 1.0 if not specified
-        means = jnp.array([mean_dict.get(p, 0.0) for p in param_names])
-        stds = jnp.array([std_dict.get(p, 1.0) for p in param_names])
+        mean_val = mc_initialiser_settings.get("mean_val", None)
+        std_val = mc_initialiser_settings.get("std_val", None)
 
-        # Check that, if mean is specified, so is std and vice versa
-        if ("means" in mc_initialiser_settings) ^ ("stds" in mc_initialiser_settings):
-            raise ValueError("Both 'means' and 'stds' must be specified together.")
-
-        # Check that there is exactly one mean/std value per parameter
-
-        if ("means" in mc_initialiser_settings) and ("stds" in mc_initialiser_settings):
+        # Both 'means' and 'stds' provided
+        if (mean_dict is not None) and (std_dict is not None):
             if len(mean_dict) != len(param_names) or len(std_dict) != len(param_names):
                 raise ValueError(
                     f"'means' and 'stds' must have exactly one entry per parameter "
                     f"(you wrote {len(mean_dict)} means and {len(std_dict)} stds for {len(param_names)} parameters)"
                 )
+            means = jnp.array([mean_dict[p] for p in param_names])
+            stds = jnp.array([std_dict[p] for p in param_names])
+
+        # Only 'means' provided
+        elif mean_dict is not None:
+            log.warning(
+                "mc_initialiser_settings: 'means' provided without 'stds'. "
+                "Using std=1.0 for all parameters."
+            )
+            means = jnp.array([mean_dict.get(p, 0.0) for p in param_names])
+            stds = jnp.ones(len(param_names))
+
+        # Only 'stds' provided
+        elif std_dict is not None:
+            log.warning(
+                "mc_initialiser_settings: 'stds' provided without 'means'. "
+                "Using mean=0.0 for all parameters."
+            )
+            means = jnp.zeros(len(param_names))
+            stds = jnp.array([std_dict.get(p, 1.0) for p in param_names])
+
+        # Nothing provided
+        else:
+            if (mean_val is None) and (std_val is None):
+                log.warning(
+                    "mc_initialiser_settings: 'means' and 'stds' not provided. "
+                    "Using default mean=0.0 and std=1.0 for all parameters."
+                )
+                mval = 0.0
+                sval = 1.0
+            elif (mean_val is not None) and (std_val is not None):
+                mval = mean_val
+                sval = std_val
+            elif (mean_val is not None) and (std_val is None):
+                raise ValueError("mc_initialiser_settings: 'std_val' missing.")
+            elif (mean_val is None) and (std_val is not None):
+                raise ValueError("mc_initialiser_settings: 'mean_val' missing.")
+            means = jnp.full(len(param_names), mval)
+            stds = jnp.full(len(param_names), sval)
 
         normal_samples = jax.random.normal(
             key=random_seed,

--- a/colibri/mc_initialisation.py
+++ b/colibri/mc_initialisation.py
@@ -42,18 +42,41 @@ def mc_initial_parameters(pdf_model, mc_initialiser_settings, replica_index):
     else:
         random_seed = jax.random.PRNGKey(replica_index)
 
+    param_names = pdf_model.param_names
+
     if mc_initialiser_settings["type"] == "normal":
-        # Currently, only one standard deviation around a zero mean is implemented
-        initial_values = jax.random.normal(
+        mean_dict = mc_initialiser_settings.get("means", {})
+        std_dict = mc_initialiser_settings.get("stds", {})
+
+        # Default mean = 0.0, std = 1.0 if not specified
+        means = jnp.array([mean_dict.get(p, 0.0) for p in param_names])
+        stds = jnp.array([std_dict.get(p, 1.0) for p in param_names])
+
+        # Check that, if mean is specified, so is std and vice versa
+        if ("means" in mc_initialiser_settings) ^ ("stds" in mc_initialiser_settings):
+            raise ValueError("Both 'means' and 'stds' must be specified together.")
+
+        # Check that there is exactly one mean/std value per parameter
+
+        if ("means" in mc_initialiser_settings) and ("stds" in mc_initialiser_settings):
+            if len(mean_dict) != len(param_names) or len(std_dict) != len(param_names):
+                raise ValueError(
+                    f"'means' and 'stds' must have exactly one entry per parameter "
+                    f"(you wrote {len(mean_dict)} means and {len(std_dict)} stds for {len(param_names)} parameters)"
+                )
+
+        normal_samples = jax.random.normal(
             key=random_seed,
-            shape=(len(pdf_model.param_names),),
+            shape=(len(param_names),),
         )
+
+        initial_values = means + stds * normal_samples
         return initial_values
 
     if mc_initialiser_settings["type"] == "uniform":
         if "bounds" in mc_initialiser_settings:
             # Use param names from the model to order bounds correctly
-            param_names = pdf_model.param_names
+            # param_names = pdf_model.param_names
             bounds_dict = mc_initialiser_settings["bounds"]
 
             missing = [p for p in param_names if p not in bounds_dict]

--- a/colibri/tests/test_mc_initialisation.py
+++ b/colibri/tests/test_mc_initialisation.py
@@ -33,18 +33,21 @@ def test_zeros_initializer():
 
 @patch("jax.random.PRNGKey")
 @patch("jax.random.normal")
-def test_normal_initializer(mock_normal, mock_PRNGKey):
+def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
     settings = {"type": "normal", "random_seed": 42}
     replica_index = 0
 
     mock_normal.return_value = jnp.array([0.1, -0.1, 0.2])
 
-    result = mc_initial_parameters(pdf_model, settings, replica_index)
+    with caplog.at_level("WARNING"):
+        result = mc_initial_parameters(pdf_model, settings, replica_index)
 
     mock_PRNGKey.assert_called_once_with(42)
     mock_normal.assert_called_once_with(
         key=jax.random.PRNGKey(42), shape=(len(pdf_model.param_names),)
     )
+
+    assert "mc_initialiser_settings: 'means' and 'stds' not provided." in caplog.text
     np.testing.assert_array_equal(result, jnp.array([0.1, -0.1, 0.2]))
 
     # Now test the case where the random_seed is not provided
@@ -101,10 +104,10 @@ def test_normal_initializer(mock_normal, mock_PRNGKey):
         "random_seed": 42,
     }
 
-    with pytest.raises(
-        ValueError, match="Both 'means' and 'stds' must be specified together."
-    ):
+    with caplog.at_level("WARNING"):
         mc_initial_parameters(pdf_model, settings_means_only, replica_index=0)
+
+    assert "Using std=1.0 for all parameters." in caplog.text
 
     # Only stds provided
     settings_stds_only = {
@@ -113,10 +116,10 @@ def test_normal_initializer(mock_normal, mock_PRNGKey):
         "random_seed": 42,
     }
 
-    with pytest.raises(
-        ValueError, match="Both 'means' and 'stds' must be specified together."
-    ):
+    with caplog.at_level("WARNING"):
         mc_initial_parameters(pdf_model, settings_stds_only, replica_index=0)
+
+    assert "Using mean=0.0 for all parameters." in caplog.text
 
     # ---- Test number of means/stds doesn't correspond to number of parameters ----
 
@@ -141,6 +144,38 @@ def test_normal_initializer(mock_normal, mock_PRNGKey):
 
     with pytest.raises(ValueError, match="must have exactly one entry per parameter"):
         mc_initial_parameters(pdf_model, settings_few_stds, replica_index=0)
+
+    # Global mean and std provided
+    settings_global = {
+        "type": "normal",
+        "mean_val": 0.1,
+        "std_val": 1.1,
+        "random_seed": 123,
+    }
+
+    mock_normal.reset_mock()
+    mock_PRNGKey.reset_mock()
+
+    # Mock: Zufallswerte für die Normalverteilung
+    mock_normal.return_value = jnp.array([0.5, -1.0, 2.0])
+    mock_PRNGKey.return_value = "mocked_key_123"
+
+    result = mc_initial_parameters(pdf_model, settings_global, replica_index=0)
+
+    expected = jnp.array(
+        [
+            0.1 + 1.1 * 0.5,  # mean + std * sample
+            0.1 + 1.1 * -1.0,
+            0.1 + 1.1 * 2.0,
+        ]
+    )
+
+    np.testing.assert_allclose(result, expected)
+
+    mock_PRNGKey.assert_called_once_with(123)
+    mock_normal.assert_called_once_with(
+        key="mocked_key_123", shape=(len(pdf_model.param_names),)
+    )
 
 
 @patch("jax.random.PRNGKey")

--- a/colibri/tests/test_mc_initialisation.py
+++ b/colibri/tests/test_mc_initialisation.py
@@ -34,6 +34,7 @@ def test_zeros_initializer():
 @patch("jax.random.PRNGKey")
 @patch("jax.random.normal")
 def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
+    # ---- Test no means or stds provided (full defaults) ----
     settings = {"type": "normal", "random_seed": 42}
     replica_index = 0
 
@@ -47,10 +48,10 @@ def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
         key=jax.random.PRNGKey(42), shape=(len(pdf_model.param_names),)
     )
 
-    assert "mc_initialiser_settings: 'means' and 'stds' not provided." in caplog.text
+    assert "mc_initialiser_settings: No 'means' or 'stds' provided." in caplog.text
     np.testing.assert_array_equal(result, jnp.array([0.1, -0.1, 0.2]))
 
-    # Now test the case where the random_seed is not provided
+    # ---- Test case where random_seed is not provided ----
     settings = {"type": "normal"}
     replica_index = 1
     mock_normal.return_value = jnp.array([0.5, -0.5, 0.0])
@@ -59,8 +60,7 @@ def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
 
     mock_PRNGKey.assert_called_with(1)
 
-    # ---- Test specified mean and standard deviation ----
-
+    # ---- Test specified mean and standard deviation (both as dicts) ----
     means = {
         "param1": 1,
         "param2": 2,
@@ -73,9 +73,7 @@ def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
         "param3": 2.0,
     }
 
-    settings_means = {"type": "normal", "means": means, "stds": stds, "random_seed": 99}
-
-    replica_index = 0
+    settings_both = {"type": "normal", "means": means, "stds": stds, "random_seed": 99}
 
     mock_normal.reset_mock()
     mock_PRNGKey.reset_mock()
@@ -83,7 +81,12 @@ def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
     mock_normal.return_value = jnp.array([0.2, -0.5, 1.0])
     mock_PRNGKey.return_value = "mocked_key_99"
 
-    result = mc_initial_parameters(pdf_model, settings_means, replica_index)
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        result = mc_initial_parameters(pdf_model, settings_both, replica_index=0)
+
+    # No warning should be issued when both are provided
+    assert len(caplog.records) == 0
 
     expected = jnp.array(
         [
@@ -95,46 +98,136 @@ def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
 
     np.testing.assert_allclose(result, expected)
 
-    # ---- Test missing means or stds ----
-
-    # Only means provided
-    settings_means_only = {
+    # ---- Test means dict provided without stds ----
+    settings_means_dict_only = {
         "type": "normal",
         "means": {"param1": 1.0, "param2": 2.0, "param3": 3.0},
         "random_seed": 42,
     }
 
     with caplog.at_level("WARNING"):
-        mc_initial_parameters(pdf_model, settings_means_only, replica_index=0)
+        caplog.clear()
+        mc_initial_parameters(pdf_model, settings_means_dict_only, replica_index=0)
 
-    assert "Using std=1.0 for all parameters." in caplog.text
+    assert "'means' provided without 'stds'" in caplog.text
+    assert "Using default std=1.0 for all parameters." in caplog.text
 
-    # Only stds provided
-    settings_stds_only = {
+    # ---- Test means scalar provided without stds ----
+    settings_means_scalar_only = {
+        "type": "normal",
+        "means": 2.5,  # scalar mean
+        "random_seed": 42,
+    }
+
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        mc_initial_parameters(pdf_model, settings_means_scalar_only, replica_index=0)
+
+    assert "'means' provided without 'stds'" in caplog.text
+    assert "Using default std=1.0 for all parameters." in caplog.text
+
+    # ---- Test stds dict provided without means ----
+    settings_stds_dict_only = {
         "type": "normal",
         "stds": {"param1": 0.1, "param2": 0.2, "param3": 0.3},
         "random_seed": 42,
     }
 
     with caplog.at_level("WARNING"):
-        mc_initial_parameters(pdf_model, settings_stds_only, replica_index=0)
+        caplog.clear()
+        mc_initial_parameters(pdf_model, settings_stds_dict_only, replica_index=0)
 
-    assert "Using mean=0.0 for all parameters." in caplog.text
+    assert "'stds' provided without 'means'" in caplog.text
+    assert "Using default mean=0.0 for all parameters." in caplog.text
 
-    # ---- Test number of means/stds doesn't correspond to number of parameters ----
-
-    # Too few means
-    settings_few_means = {
+    # ---- Test stds scalar provided without means ----
+    settings_stds_scalar_only = {
         "type": "normal",
-        "means": {"param1": 0.0, "param2": 0.0},  # Only 2 means
-        "stds": {"param1": 1.0, "param2": 1.0, "param3": 1.0},  # Correct number of stds
+        "stds": 0.5,  # scalar std
         "random_seed": 42,
     }
 
-    with pytest.raises(ValueError, match="must have exactly one entry per parameter"):
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        mc_initial_parameters(pdf_model, settings_stds_scalar_only, replica_index=0)
+
+    assert "'stds' provided without 'means'" in caplog.text
+    assert "Using default mean=0.0 for all parameters." in caplog.text
+
+    # ---- Test scalar means and stds together ----
+    settings_scalars = {
+        "type": "normal",
+        "means": 1.5,  # scalar mean
+        "stds": 0.8,  # scalar std
+        "random_seed": 123,
+    }
+
+    mock_normal.reset_mock()
+    mock_PRNGKey.reset_mock()
+
+    mock_normal.return_value = jnp.array([0.5, -1.0, 2.0])
+    mock_PRNGKey.return_value = "mocked_key_123"
+
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        result = mc_initial_parameters(pdf_model, settings_scalars, replica_index=0)
+
+    # No warning should be issued when both are provided
+    assert len(caplog.records) == 0
+
+    expected = jnp.array(
+        [
+            1.5 + 0.8 * 0.5,  # mean + std * sample
+            1.5 + 0.8 * -1.0,
+            1.5 + 0.8 * 2.0,
+        ]
+    )
+
+    np.testing.assert_allclose(result, expected)
+
+    # ---- Test mixed dict/scalar (means dict, stds scalar) ----
+    settings_mixed = {
+        "type": "normal",
+        "means": {"param1": 1.0, "param2": 2.0, "param3": 3.0},
+        "stds": 0.5,  # scalar std applied to all
+        "random_seed": 456,
+    }
+
+    mock_normal.reset_mock()
+    mock_normal.return_value = jnp.array([1.0, 0.0, -1.0])
+
+    with caplog.at_level("WARNING"):
+        caplog.clear()
+        result = mc_initial_parameters(pdf_model, settings_mixed, replica_index=0)
+
+    # No warning should be issued
+    assert len(caplog.records) == 0
+
+    expected = jnp.array(
+        [
+            1.0 + 0.5 * 1.0,  # 1.5
+            2.0 + 0.5 * 0.0,  # 2.0
+            3.0 + 0.5 * -1.0,  # 2.5
+        ]
+    )
+
+    np.testing.assert_allclose(result, expected)
+
+    # ---- Test validation errors ----
+    # Too few means in dict
+    settings_few_means = {
+        "type": "normal",
+        "means": {"param1": 0.0, "param2": 0.0},  # Only 2 means
+        "stds": {"param1": 1.0, "param2": 1.0, "param3": 1.0},
+        "random_seed": 42,
+    }
+
+    with pytest.raises(
+        ValueError, match="'means' dict must have one entry per parameter"
+    ):
         mc_initial_parameters(pdf_model, settings_few_means, replica_index=0)
 
-    # Too few stds
+    # Too few stds in dict
     settings_few_stds = {
         "type": "normal",
         "means": {"param1": 0.0, "param2": 0.0, "param3": 0.0},
@@ -142,40 +235,30 @@ def test_normal_initializer(mock_normal, mock_PRNGKey, caplog):
         "random_seed": 42,
     }
 
-    with pytest.raises(ValueError, match="must have exactly one entry per parameter"):
+    with pytest.raises(
+        ValueError, match="'stds' dict must have one entry per parameter"
+    ):
         mc_initial_parameters(pdf_model, settings_few_stds, replica_index=0)
 
-    # Global mean and std provided
-    settings_global = {
+    # Invalid type for means
+    settings_invalid_means = {
         "type": "normal",
-        "mean_val": 0.1,
-        "std_val": 1.1,
-        "random_seed": 123,
+        "means": ["invalid", "list"],  # Invalid type
+        "random_seed": 42,
     }
 
-    mock_normal.reset_mock()
-    mock_PRNGKey.reset_mock()
+    with pytest.raises(TypeError, match="'means' must be dict or scalar"):
+        mc_initial_parameters(pdf_model, settings_invalid_means, replica_index=0)
 
-    # Mock: Zufallswerte für die Normalverteilung
-    mock_normal.return_value = jnp.array([0.5, -1.0, 2.0])
-    mock_PRNGKey.return_value = "mocked_key_123"
+    # Invalid type for stds
+    settings_invalid_stds = {
+        "type": "normal",
+        "stds": ["invalid", "list"],  # Invalid type
+        "random_seed": 42,
+    }
 
-    result = mc_initial_parameters(pdf_model, settings_global, replica_index=0)
-
-    expected = jnp.array(
-        [
-            0.1 + 1.1 * 0.5,  # mean + std * sample
-            0.1 + 1.1 * -1.0,
-            0.1 + 1.1 * 2.0,
-        ]
-    )
-
-    np.testing.assert_allclose(result, expected)
-
-    mock_PRNGKey.assert_called_once_with(123)
-    mock_normal.assert_called_once_with(
-        key="mocked_key_123", shape=(len(pdf_model.param_names),)
-    )
+    with pytest.raises(TypeError, match="'stds' must be dict or scalar"):
+        mc_initial_parameters(pdf_model, settings_invalid_stds, replica_index=0)
 
 
 @patch("jax.random.PRNGKey")

--- a/colibri/tests/test_mc_initialisation.py
+++ b/colibri/tests/test_mc_initialisation.py
@@ -56,6 +56,92 @@ def test_normal_initializer(mock_normal, mock_PRNGKey):
 
     mock_PRNGKey.assert_called_with(1)
 
+    # ---- Test specified mean and standard deviation ----
+
+    means = {
+        "param1": 1,
+        "param2": 2,
+        "param3": 3,
+    }
+
+    stds = {
+        "param1": 0.5,
+        "param2": 1.0,
+        "param3": 2.0,
+    }
+
+    settings_means = {"type": "normal", "means": means, "stds": stds, "random_seed": 99}
+
+    replica_index = 0
+
+    mock_normal.reset_mock()
+    mock_PRNGKey.reset_mock()
+
+    mock_normal.return_value = jnp.array([0.2, -0.5, 1.0])
+    mock_PRNGKey.return_value = "mocked_key_99"
+
+    result = mc_initial_parameters(pdf_model, settings_means, replica_index)
+
+    expected = jnp.array(
+        [
+            1.0 + 0.5 * 0.2,  # 1.1
+            2.0 + 1.0 * -0.5,  # 1.5
+            3.0 + 2.0 * 1.0,  # 5.0
+        ]
+    )
+
+    np.testing.assert_allclose(result, expected)
+
+    # ---- Test missing means or stds ----
+
+    # Only means provided
+    settings_means_only = {
+        "type": "normal",
+        "means": {"param1": 1.0, "param2": 2.0, "param3": 3.0},
+        "random_seed": 42,
+    }
+
+    with pytest.raises(
+        ValueError, match="Both 'means' and 'stds' must be specified together."
+    ):
+        mc_initial_parameters(pdf_model, settings_means_only, replica_index=0)
+
+    # Only stds provided
+    settings_stds_only = {
+        "type": "normal",
+        "stds": {"param1": 0.1, "param2": 0.2, "param3": 0.3},
+        "random_seed": 42,
+    }
+
+    with pytest.raises(
+        ValueError, match="Both 'means' and 'stds' must be specified together."
+    ):
+        mc_initial_parameters(pdf_model, settings_stds_only, replica_index=0)
+
+    # ---- Test number of means/stds doesn't correspond to number of parameters ----
+
+    # Too few means
+    settings_few_means = {
+        "type": "normal",
+        "means": {"param1": 0.0, "param2": 0.0},  # Only 2 means
+        "stds": {"param1": 1.0, "param2": 1.0, "param3": 1.0},  # Correct number of stds
+        "random_seed": 42,
+    }
+
+    with pytest.raises(ValueError, match="must have exactly one entry per parameter"):
+        mc_initial_parameters(pdf_model, settings_few_means, replica_index=0)
+
+    # Too few stds
+    settings_few_stds = {
+        "type": "normal",
+        "means": {"param1": 0.0, "param2": 0.0, "param3": 0.0},
+        "stds": {"param1": 1.0},  # Only 1 std
+        "random_seed": 42,
+    }
+
+    with pytest.raises(ValueError, match="must have exactly one entry per parameter"):
+        mc_initial_parameters(pdf_model, settings_few_stds, replica_index=0)
+
 
 @patch("jax.random.PRNGKey")
 @patch("jax.random.uniform")


### PR DESCRIPTION
For a MC fit, the user can now initialise with a "normal" distribution, and chose between:

- using the default values, 0 mean and 1 std
- setting specific values for the mean and standard deviation for each parameter
- setting global values for all parameters, different to the default (eg. initialise all parameters with mean 2 and std 5)

If only one of the values (eg. only means but no stds) are specified, then the defaults will be used.

The code also checks that if means or stds are specified for each parameter, the number of values specified matches the number of standard parameters in the model. 