### PR TITLE
mc_postfit nan replicas

### DIFF
--- a/colibri/scripts/mc_postfit.py
+++ b/colibri/scripts/mc_postfit.py
@@ -83,7 +83,7 @@ def main():
                 or df["training_loss"].iloc[-1] is pd.NA
                 or pd.isna(df["training_loss"].iloc[-1])
             ):
-                print(f"Skipping {replica} - empty or NaN training_loss")
+                log.warning(f"Skipping replica {replica} - empty or NaN training_loss")
                 continue
 
             final_loss = df.iloc[-1]["training_loss"]

--- a/colibri/scripts/mc_postfit.py
+++ b/colibri/scripts/mc_postfit.py
@@ -93,7 +93,7 @@ def main():
             valid_replicas.append(replica)
 
         except (FileNotFoundError, KeyError, IndexError) as e:
-            print(f"Skipping {replica} - error reading file: {e}")
+            log.critical(f"Skipping replica {replica} - error reading file: {e}")
             continue
 
     mean_loss = jnp.mean(final_losses)

--- a/colibri/scripts/mc_postfit.py
+++ b/colibri/scripts/mc_postfit.py
@@ -72,11 +72,6 @@ def main():
     replicas_list = sorted(list(replicas_path.iterdir()))
 
     final_losses = jnp.array([])
-    # Loop over the replicas and check their final loss
-    # for replica in replicas_list:
-    #     # Get last non-blank iteration from the mc_loss.csv file
-    #     final_loss = pd.read_csv(replica / "mc_loss.csv").iloc[-1]["training_loss"]
-    #     final_losses = jnp.concatenate((final_losses, jnp.array([final_loss])), axis=0)
 
     valid_replicas = []  # Keep track of which replicas are valid
 

--- a/colibri/scripts/mc_postfit.py
+++ b/colibri/scripts/mc_postfit.py
@@ -73,12 +73,33 @@ def main():
 
     final_losses = jnp.array([])
     # Loop over the replicas and check their final loss
+    # for replica in replicas_list:
+    #     # Get last non-blank iteration from the mc_loss.csv file
+    #     final_loss = pd.read_csv(replica / "mc_loss.csv").iloc[-1]["training_loss"]
+    #     final_losses = jnp.concatenate((final_losses, jnp.array([final_loss])), axis=0)
+
+    valid_replicas = []  # Keep track of which replicas are valid
+
     for replica in replicas_list:
-        # Get last non-blank iteration from the mc_loss.csv file
-        final_loss = (
-            pd.read_csv(replica / "mc_loss.csv")["training_loss"].dropna().iloc[-1]
-        )
-        final_losses = jnp.concatenate((final_losses, jnp.array([final_loss])), axis=0)
+        try:
+            df = pd.read_csv(replica / "mc_loss.csv")
+            if (
+                df.empty
+                or df["training_loss"].iloc[-1] is pd.NA
+                or pd.isna(df["training_loss"].iloc[-1])
+            ):
+                print(f"Skipping {replica} - empty or NaN training_loss")
+                continue
+
+            final_loss = df.iloc[-1]["training_loss"]
+            final_losses = jnp.concatenate(
+                (final_losses, jnp.array([final_loss])), axis=0
+            )
+            valid_replicas.append(replica)
+
+        except (FileNotFoundError, KeyError, IndexError) as e:
+            print(f"Skipping {replica} - error reading file: {e}")
+            continue
 
     mean_loss = jnp.mean(final_losses)
     std_loss = jnp.std(final_losses)
@@ -89,7 +110,7 @@ def main():
     # We will copy the replicas and order them starting with 0
     # and increasing the index for each good replica we find
     i = 0
-    for replica, loss in zip(replicas_list, final_losses):
+    for replica, loss in zip(valid_replicas, final_losses):
 
         index = int(replica.name.split("_")[1])
 

--- a/colibri/scripts/mc_postfit.py
+++ b/colibri/scripts/mc_postfit.py
@@ -74,8 +74,10 @@ def main():
     final_losses = jnp.array([])
     # Loop over the replicas and check their final loss
     for replica in replicas_list:
-        # Get last iteration from the mc_loss.csv file
-        final_loss = pd.read_csv(replica / "mc_loss.csv").iloc[-1]["training_loss"]
+        # Get last non-blank iteration from the mc_loss.csv file
+        final_loss = (
+            pd.read_csv(replica / "mc_loss.csv")["training_loss"].dropna().iloc[-1]
+        )
         final_losses = jnp.concatenate((final_losses, jnp.array([final_loss])), axis=0)
 
     mean_loss = jnp.mean(final_losses)


### PR DESCRIPTION
mc_postfit now skipps replicas that have returned 0 or nan values for the final loss, and prints which replicas are being skipped and why. Up until now, these replicas where being taken into account in the calculation of the mean_loss, which made the postfit fail, with a misleading error message.