### PR TITLE
Fix closure_test_level feature for model-specific closure tests

### DIFF
--- a/colibri/closure_test.py
+++ b/colibri/closure_test.py
@@ -73,7 +73,9 @@ def closure_test_colibri_model_pdf(closure_test_model_settings, FIT_XGRID):
 
     # Compute the pdf grid
     pdf_grid_func = pdf_model.grid_values_func(FIT_XGRID)
-    params = jnp.array(closure_test_model_settings["parameters"])
+    params = jnp.array(
+        [closure_test_model_settings["parameters"][p] for p in pdf_model.param_names]
+    )
     pdf_grid = pdf_grid_func(params)
 
     return pdf_grid


### PR DESCRIPTION
This feature was giving an error when running model-specific closure tests, due to the way in which the parameters were turned into an array.