### PR TITLE
Fix unittest python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,5 @@
 name: Tests
+
 on:
   push:
     branches: [ "main" ]
@@ -11,10 +12,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -25,35 +22,19 @@ jobs:
           miniforge-version: latest
           activate-environment: colibri-dev
           use-mamba: true
+          auto-activate-base: false
 
       - name: Cache Conda packages
         id: conda-pkgs
         uses: actions/cache@v3
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}-${{ hashFiles('environment.yml') }}
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
 
-      - name: Create env with matrix Python
+      - name: Create environment from environment.yml
         shell: bash -l {0}
         run: |
-          mamba create -n colibri-dev "python=${{ matrix.python-version }}.*" -y
-
-      - name: Update from environment.yml
-        shell: bash -l {0}
-        run: |
-          mamba env update -n colibri-dev -f environment.yml --prune
-
-      - name: Enforce matrix Python
-        shell: bash -l {0}
-        run: |
-          mamba install -n colibri-dev "python=${{ matrix.python-version }}.*" -y
-
-      - name: Show versions
-        shell: bash -l {0}
-        run: |
-          which python
-          python -V
-          conda list python | sed -n '1,6p'
+          mamba env create -n colibri-dev -f environment.yml
 
       - name: Lint
         shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,4 @@
-# This workflow install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
-
 name: Tests
-
 on:
   push:
     branches: [ "main" ]
@@ -10,60 +6,69 @@ on:
     branches: [ "main" ]
 
 env:
-  CACHE_NUMBER: 0  # increase to reset cache manually
+  CACHE_NUMBER: 0
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set up Conda
-      uses: conda-incubator/setup-miniconda@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-        miniforge-version: latest
-        activate-environment: colibri-dev
-        use-mamba: true    
-    
-    - name: Cache Conda packages
-      uses: actions/cache@v3
-      with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('environment.yml') }}
-    
-    - name: Update environment
-      run: mamba env update -n colibri-dev -f environment.yml
-      if: steps.cache.outputs.cache-hit != 'true'
+      - uses: actions/checkout@v4
 
-    - name: Lint with flake8
-      shell: bash -l {0}
-      run: |
-        pip install flake8
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      shell: bash -l {0}
-      run: |
-        pip install pytest
-        pip install pytest-cov
-        pytest -p no:warnings colibri/tests --cov=colibri --cov-report=xml --cov-config=.coveragerc
-    
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.2.0
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          activate-environment: colibri-dev
+          use-mamba: true
+
+      - name: Cache Conda packages
+        id: conda-pkgs
+        uses: actions/cache@v3
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ matrix.python-version }}-${{ hashFiles('environment.yml') }}
+
+      - name: Create env with matrix Python
+        shell: bash -l {0}
+        run: |
+          mamba create -n colibri-dev "python=${{ matrix.python-version }}.*" -y
+
+      - name: Update from environment.yml
+        shell: bash -l {0}
+        run: |
+          mamba env update -n colibri-dev -f environment.yml --prune
+
+      - name: Enforce matrix Python
+        shell: bash -l {0}
+        run: |
+          mamba install -n colibri-dev "python=${{ matrix.python-version }}.*" --update-specs -y
+
+      - name: Show versions
+        shell: bash -l {0}
+        run: |
+          which python
+          python -V
+          conda list python | sed -n '1,6p'
+
+      - name: Lint
+        shell: bash -l {0}
+        run: |
+          pip install flake8
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Test
+        shell: bash -l {0}
+        run: |
+          pip install pytest pytest-cov
+          pytest -p no:warnings colibri/tests --cov=colibri --cov-report=xml --cov-config=.coveragerc
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4.2.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,6 @@ jobs:
         run: |
           mamba env update -n colibri-dev -f environment.yml --prune
 
-      - name: Enforce matrix Python
-        shell: bash -l {0}
-        run: |
-          mamba install -n colibri-dev "python=${{ matrix.python-version }}.*" --update-specs -y
-
       - name: Show versions
         shell: bash -l {0}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           mamba env update -n colibri-dev -f environment.yml --prune
 
+      - name: Enforce matrix Python
+        shell: bash -l {0}
+        run: |
+          mamba install -n colibri-dev "python=${{ matrix.python-version }}.*" -y
+
       - name: Show versions
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
This PR modifies the unit test workflow so that it does not erroneously indicate it is done with python 3.11. The tests are run with the default conda installation using the environment.yaml, which at the moment is picking up python 3.12.