### PR TITLE
Fix conftest forward map

### DIFF
--- a/colibri/tests/conftest.py
+++ b/colibri/tests/conftest.py
@@ -290,8 +290,8 @@ class TestPDFModel(PDFModel):
 
 MOCK_PDF_MODEL = Mock()
 MOCK_PDF_MODEL.param_names = ["param1", "param2"]
-MOCK_PDF_MODEL.grid_values_func = lambda xgrid: lambda params: np.sum(
-    np.array([param * TEST_PDF_GRID for param in params]), axis=0
+MOCK_PDF_MODEL.grid_values_func = lambda xgrid: lambda params: jnp.sum(
+    jnp.array([param * TEST_PDF_GRID for param in params]), axis=0
 )
 """
 Mock PDF model with 2 parameters and grid_values_func simple mult add operation on np.ones grid.
@@ -334,10 +334,10 @@ This mocks a POS fast kernel mapping the PDF grid to 2 datapoints.
 """
 
 
-TEST_FORWARD_MAP_DIS = lambda pdf, fk_arrays: np.einsum("ijk,jk->i", fk_arrays, pdf)
+TEST_FORWARD_MAP_DIS = lambda pdf, fk_arrays: jnp.einsum("ijk,jk->i", fk_arrays[0], pdf)
 """
 Mock DIS forward map function for testing purposes.
-Function expects a DIS-like fast kernel array of shape (N_data, TEST_N_FL, TEST_N_XGRID) and a PDF of shape (TEST_N_FL, TEST_N_XGRID).
+Function expects a tuple of DIS-like fast kernel array of shape (N_data, TEST_N_FL, TEST_N_XGRID) and a PDF of shape (TEST_N_FL, TEST_N_XGRID).
 """
 
 

--- a/colibri/tests/test_pdf_model.py
+++ b/colibri/tests/test_pdf_model.py
@@ -44,7 +44,7 @@ def test_pred_and_pdf_func():
     pred_and_pdf = model.pred_and_pdf_func(TEST_XGRID, TEST_FORWARD_MAP_DIS)
 
     params = jnp.array([2, 3])
-    predictions, pdf = pred_and_pdf(params, TEST_FK_ARRAYS[0])
+    predictions, pdf = pred_and_pdf(params, TEST_FK_ARRAYS)
 
     expected_predictions = jnp.einsum("ijk,jk->i", TEST_FK_ARRAYS[0], pdf)
 


### PR DESCRIPTION
This PR is addressing a "strange" problem.

The problem is the following. If tests are run by doing `pytest` in the root, everything works.
However, if one wants to only run the specific tests of the likelihood for example (but not only, just an example):
`pytest colibri/tests/test_likelihood.py`
then the test fail.

This seems to be due to an inconsistent use of np and jnp, but also a flawed logic in the `TEST_FORWARD_MAP_DIS`, which was expecting a single array, while `TEST_FK_ARRAYS` is a tuple and that's how it is provided by the LogLikelihood class for example.