### PR TITLE
Add hessian fit option in evolve

### DIFF
--- a/colibri/doc/sphinx/source/tutorials/scripts/evolution.rst
+++ b/colibri/doc/sphinx/source/tutorials/scripts/evolution.rst
@@ -17,6 +17,15 @@ It can be executed from the command line as follows:
 
 where ``<name_fit>`` is the name of the fit you want to evolve. The script
 also has a ``--help`` option that will show you all the options available.
+If the performed fit is a fit which requires ``ErrorType=hessian``, 
+i.e. the PDF grids to evolve are eigenvectors of the covariance matrix, 
+you can specify the option
+
+.. code-block:: bash
+
+   evolve_fit <name_fit> --hessian_fit True
+
+to correctly produce the LHAPDF set.
 For more information on the evolution see also the helper from the
 ``evolven3fit`` script.
 

--- a/colibri/scripts/evolve_fit.py
+++ b/colibri/scripts/evolve_fit.py
@@ -155,6 +155,12 @@ def main():
         choices=["evolve"],
         help="The action to run (defaults to 'evolve').",
     )
+    parser.add_argument(
+        "--hessian_fit",
+        type=bool,
+        default=False,
+        help="Specify if the fit is hessian (default is False)",
+    )
     parser.add_argument("name_fit", help="The name of the fit directory")
     args = parser.parse_args()
 
@@ -178,6 +184,10 @@ def main():
 
     # Run evolven3fit: invoke the underlying CLI with both args
     sys.argv = ["evolven3fit", args.action, args.name_fit]
+    # The evolven3fit arg parser has a misuse and if you pass --hessian_fit False
+    # it will evaluate as bool("False")=True, so we only pass --hessian_fit True if needed
+    if args.hessian_fit:
+        sys.argv += ["--hessian_fit", "True"]
     evolven3fit_main()
 
     # Run postfit emulator to generate the postfit directory and symlinks


### PR DESCRIPTION
This PR adds the possibility to ask for a fit with` ErrorType=hessian` in the evolution code.
This is needed if the produced fit is given in terms of eigenvectors instead of replicas.