### PR TITLE
Fix tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9"
 prompt_toolkit = "*"
 h5py = "*"
 


### PR DESCRIPTION
Installation now defaults to python 3.13 and therefore there was a clash with colibri. However, it seems that everything is fine with python 3.13, so I think it is good to allow it.