### PR TITLE
No to python 3.14

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python >= 3.11
+  - python >= 3.11,<3.14
   - mpich
   - lhapdf
   - pandoc


### PR DESCRIPTION
This PR limits the version of python to stay below 3.14. Now conda defaults to install python 3.14 and some packages do not like that, making the installation and the tests fail.