### PR TITLE
[doc] remove use_gen_t0 flag as it is obsolete

### DIFF
--- a/colibri/doc/sphinx/source/tutorials/running_fits/running_hessian.rst
+++ b/colibri/doc/sphinx/source/tutorials/running_fits/running_hessian.rst
@@ -109,7 +109,6 @@ The following runcard can be used to run a Hessian fit with Colibri.
         #         transition_steps: 10000
 
     # Training settings
-    use_gen_t0: True             # Whether the t0 covariance is used to generated pseudodata.
     max_epochs: 30000
 
     param_initialiser_settings:               

--- a/colibri/doc/sphinx/source/tutorials/running_fits/running_mc_replica.rst
+++ b/colibri/doc/sphinx/source/tutorials/running_fits/running_mc_replica.rst
@@ -107,8 +107,7 @@ executable.
         #         transition_begin: 3000
         #         transition_steps: 10000
 
-    # Monte Carlo settings
-    use_gen_t0: True                       # Whether the t0 covariance is used to generated pseudodata.
+    # Training settings
     max_epochs: 300                        # The max number of epochs in Monte Carlo training.
     mc_validation_fraction: 0.2            # The fraction of the data used for validation in Monte Carlo training.
 


### PR DESCRIPTION
This flag was removed in a previous PR.