### PR TITLE
[WIP] Load commondata from existing n3fit fit

### DIFF
--- a/colibri/commondata_utils.py
+++ b/colibri/commondata_utils.py
@@ -12,6 +12,8 @@ import jax.numpy as jnp
 from colibri.theory_predictions import make_pred_dataset
 from colibri.core import CentralCovmatIndex
 
+from validphys.loader import Loader
+
 
 def experimental_commondata_tuple(data):
     """
@@ -28,6 +30,50 @@ def experimental_commondata_tuple(data):
         Tuple of nnpdf_data.coredata.CommonData instances.
     """
     return tuple(data.load_commondata_instance())
+
+
+def experimental_commondata_tuple_from_fit(
+    data, theoryid, use_fitcommondata=False, fit=None
+):
+    """
+    Returns a tuple of commondata instances with experimental central values
+    loaded from existing n3fit fit.
+
+    Parameters
+    ----------
+    data: validphys.core.DataGroupSpec
+
+    Returns
+    -------
+    tuple
+        Tuple of nnpdf_data.coredata.CommonData instances.
+    """
+    if use_fitcommondata:
+        if not fit:
+            raise ConfigError(
+                f"use_fitcommondata set to True but no fit provided in the runcard."
+            )
+        ds_inputs = []
+        for ds in data.datasets:
+            ds_inputs.append(
+                Loader().check_dataset(
+                    ds.name,
+                    theoryid=theoryid.id,
+                    cuts="internal",
+                    use_fitcommondata=True,
+                    fit=fit,
+                )
+            )
+        data_group_spec = Loader().check_experiment("DataGroupSpec_from_fit", ds_inputs)
+
+        # Construct a list of commondata object cointaining level-1 data
+        sample_list = []
+        for datasetspec in data_group_spec.datasets:
+            cd = datasetspec.load_commondata()
+            sample_list.append(cd)
+        return tuple(sample_list)
+    else:
+        return
 
 
 def level_0_commondata_tuple(

--- a/colibri/config.py
+++ b/colibri/config.py
@@ -641,7 +641,7 @@ class colibriConfig(Config):
     def parse_fit(self, fit=None):
         return API.fit(fit=fit)
 
-    def parse_closure_test_result(self, name):
+    def parse_closure_test_pdf(self, name):
         """PDF set used to generate fakedata"""
         if name == "colibri_model":
             return name

--- a/colibri/config.py
+++ b/colibri/config.py
@@ -22,6 +22,7 @@ from reportengine.configparser import ConfigError, explicit_node
 from validphys import covmats
 from validphys.config import Config, Environment
 from validphys.fkparser import load_fktable
+from validphys.api import API
 
 comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
@@ -590,13 +591,18 @@ class colibriConfig(Config):
         return optimizer_settings
 
     @explicit_node
-    def produce_commondata_tuple(self, closure_test_level=False):
+    def produce_commondata_tuple(
+        self, closure_test_level=False, use_fitcommondata=False
+    ):
         """
         Produces a commondata tuple node in the reportengine dag
         according to some options
         """
         if closure_test_level is False:
-            return commondata_utils.experimental_commondata_tuple
+            if use_fitcommondata is False:
+                return commondata_utils.experimental_commondata_tuple
+            else:
+                return commondata_utils.experimental_commondata_tuple_from_fit
         elif closure_test_level == 0:
             return commondata_utils.level_0_commondata_tuple
         elif closure_test_level == 1:
@@ -607,7 +613,9 @@ class colibriConfig(Config):
             )
 
     @explicit_node
-    def produce_general_covariance_matrix(self, use_t0_covmat: bool = True):
+    def produce_general_covariance_matrix(
+        self, use_t0_covmat: bool = True, use_fitcommondata: bool = False
+    ):
         """
         Produces the covariance matrix used in the fit and noise generation for level 1 data and MC replicas.
         This covariance matrix is used in:
@@ -615,11 +623,25 @@ class colibriConfig(Config):
         - mc_log_likelihood for the monte carlo fit
         """
         if use_t0_covmat:
-            return colibri_covmats.dataset_inputs_t0_covmat_from_systematics
+            if use_fitcommondata:
+                return (
+                    colibri_covmats.dataset_inputs_t0_covmat_from_systematics_from_fit
+                )
+            else:
+                return colibri_covmats.dataset_inputs_t0_covmat_from_systematics
         else:
-            return colibri_covmats.dataset_inputs_covmat_from_systematics
+            if use_fitcommondata:
+                return colibri_covmats.dataset_inputs_covmat_from_systematics_from_fit
+            else:
+                return colibri_covmats.dataset_inputs_covmat_from_systematics
 
-    def parse_closure_test_pdf(self, name):
+    def parse_use_fitcommondata(self, use_fitcommondata=False):
+        return use_fitcommondata
+
+    def parse_fit(self, fit=None):
+        return API.fit(fit=fit)
+
+    def parse_closure_test_result(self, name):
         """PDF set used to generate fakedata"""
         if name == "colibri_model":
             return name

--- a/colibri/covmats.py
+++ b/colibri/covmats.py
@@ -77,6 +77,23 @@ def dataset_inputs_covmat_from_systematics(
     return covmat
 
 
+def dataset_inputs_covmat_from_systematics_from_fit(
+    data,
+    experimental_commondata_tuple_from_fit,
+):
+    covmat = jnp.array(
+        covmats.dataset_inputs_covmat_from_systematics(
+            experimental_commondata_tuple_from_fit,
+            data.dsinputs,
+            use_weights_in_covmat=False,
+            norm_threshold=None,
+            _list_of_central_values=None,
+            _only_additive=False,
+        )
+    )
+    return covmat
+
+
 def colibri_dataset_inputs_t0_predictions(
     _pred_t0data, t0_pdf_grid, fast_kernel_arrays
 ):
@@ -117,6 +134,29 @@ def dataset_inputs_t0_covmat_from_systematics(
     covmat = jnp.array(
         covmats.dataset_inputs_t0_covmat_from_systematics(
             experimental_commondata_tuple,
+            data_input=data.dsinputs,
+            use_weights_in_covmat=False,
+            norm_threshold=None,
+            dataset_inputs_t0_predictions=colibri_dataset_inputs_t0_predictions,
+        )
+    )
+    return covmat
+
+
+def dataset_inputs_t0_covmat_from_systematics_from_fit(
+    data,
+    experimental_commondata_tuple_from_fit,
+    colibri_dataset_inputs_t0_predictions,
+):
+    """
+    Similar as `validphys.covmats.dataset_inputs_t0_covmat_from_systematics`
+    but jax.numpy array.
+
+    Note: see production rule in `config.py` for commondata_tuple options.
+    """
+    covmat = jnp.array(
+        covmats.dataset_inputs_t0_covmat_from_systematics(
+            experimental_commondata_tuple_from_fit,
             data_input=data.dsinputs,
             use_weights_in_covmat=False,
             norm_threshold=None,


### PR DESCRIPTION
Using the flag `use_fitcommondata` one can load the commondata used in a pre-existing n3fit fit, which has to be specified in the runcard. 

By setting in the runcard 
```
use_fitcommondata: True 
fit: n3fit_fit
```
the commondata specified in the runcard will be taken from the fit `n3fit_fit`. The covariance matrix will also be generated consistently starting from the central values of the commondata from `n3fit_fit`.

This feature would allow to run a closure test using the exact same l1 pseudo data generated in a n3fit closure (which are different from the ones generated internally by colibri), which is useful if one wants to perform an apple to apple comparison between n3fit and a colibri model in the context of closure tests.