### PR TITLE
Update blackjax from main code

### DIFF
--- a/colibri/blackjax_fit.py
+++ b/colibri/blackjax_fit.py
@@ -97,7 +97,10 @@ def blackjax_fit(
 
     t0 = time.time()
     with tqdm.tqdm(desc="Dead points", unit=" dead points") as pbar:
-        while not state.logZ_live - state.logZ < blackjax_settings["log_precision"]:
+        while (
+            not state.integrator.logZ_live - state.integrator.logZ
+            < blackjax_settings["log_precision"]
+        ):
             (state, rng_key), dead_info = one_step((state, rng_key), None)
             dead.append(dead_info)
             pbar.update(n_delete)
@@ -114,7 +117,7 @@ def blackjax_fit(
     ess_value = int(ess(ess_key, final_states))
     logw = log_weights(rng_key, final_states)
     logzs = logsumexp(logw, axis=0)
-    full_samples = sample(sample_key, final_states, ess_value)
+    full_samples = sample(sample_key, final_states, ess_value).position
 
     # Get number of posterior samples to resample
     n_posterior_samples = blackjax_settings["n_posterior_samples"]
@@ -139,9 +142,9 @@ def blackjax_fit(
 
     # write out an anesthetic dataframe
     nested_samples = anesthetic.NestedSamples(
-        data=final_states.particles,
-        logL=final_states.loglikelihood,
-        logL_birth=final_states.loglikelihood_birth,
+        data=final_states.particles.position,
+        logL=final_states.particles.loglikelihood,
+        logL_birth=final_states.particles.loglikelihood_birth,
         columns=forward_map.param_names,
     )
     # write nested_samples.csv to blackjax_logs
@@ -155,8 +158,8 @@ def blackjax_fit(
 
     # Compute bayesian metrics (similar to UltraNest)
     # Find maximum likelihood point
-    max_ll_idx = jnp.argmax(final_states.loglikelihood)
-    min_chi2 = -2 * final_states.loglikelihood[max_ll_idx]
+    max_ll_idx = jnp.argmax(final_states.particles.loglikelihood)
+    min_chi2 = -2 * final_states.particles.loglikelihood[max_ll_idx]
 
     # Compute average chi2 over full samples
     avg_chi2 = jnp.array(

--- a/colibri/tests/test_blackjax_fit.py
+++ b/colibri/tests/test_blackjax_fit.py
@@ -119,10 +119,13 @@ def test_blackjax_fit_truncates_posterior_and_warns(caplog):
     log_likelihood = lambda x: -jnp.sum(x**2)
 
     # --- minimal blackjax.nss mock ---
+    # blackjax.ns.nss states carry the evidence estimates on the integrator
     fake_algo = types.SimpleNamespace(
         init=lambda particles: types.SimpleNamespace(
-            logZ=0.0,
-            logZ_live=0.0,
+            integrator=types.SimpleNamespace(
+                logZ=0.0,
+                logZ_live=0.0,
+            )
         )
     )
 
@@ -132,15 +135,19 @@ def test_blackjax_fit_truncates_posterior_and_warns(caplog):
         patch("colibri.blackjax_fit.ess", return_value=2),
         patch("colibri.blackjax_fit.log_weights", return_value=jnp.zeros(5)),
         patch(
-            "colibri.blackjax_fit.sample", return_value=jnp.ones((2, 2))
+            "colibri.blackjax_fit.sample",
+            return_value=types.SimpleNamespace(position=jnp.ones((2, 2))),
         ),  # only 2 samples
         patch("colibri.blackjax_fit.resample_from_ns_posterior") as mock_resample,
         patch("colibri.blackjax_fit.anesthetic.NestedSamples"),
     ):
+        # finalise returns an NSInfo whose particles hold positions and logL info
         mock_finalise.return_value = types.SimpleNamespace(
-            particles=jnp.ones((5, 2)),
-            loglikelihood=jnp.arange(5.0),
-            loglikelihood_birth=jnp.zeros(5),
+            particles=types.SimpleNamespace(
+                position=jnp.ones((5, 2)),
+                loglikelihood=jnp.arange(5.0),
+                loglikelihood_birth=jnp.zeros(5),
+            )
         )
 
         caplog.set_level("WARNING")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ nnpdf = { git = "https://github.com/NNPDF/nnpdf" }
 anesthetic = "^2.10.2"
 tfp-nightly = { extras = ["jax"], version = "*" }
 tf-keras = "*"
-blackjax = {git = "https://github.com/handley-lab/blackjax", tag = "v0.1.0-beta"}
+blackjax = "*"
 
 
 [tool.poetry.extras]


### PR DESCRIPTION
This PR installs blackjax from the main code, since now the NS functionality has been merged. Some things have changed in the implementation of it and the interface to it as well. This PR also adapts the code so that it keeps working with the release version of blackjax.